### PR TITLE
fix: Check for empty Configuration

### DIFF
--- a/Classes/Domain/Service/ProxyCacheService.php
+++ b/Classes/Domain/Service/ProxyCacheService.php
@@ -68,7 +68,7 @@ class ProxyCacheService
         if($this->proxyCacheApiConfiguration) {
             foreach ($this->proxyCacheApiConfiguration as $configuration) {
                 if(array_key_exists('apiKey', $configuration) && array_key_exists('zoneName', $configuration)) {
-                    if($zoneName === null || $zoneName === $configuration['zoneName']) {
+                    if(!empty($zoneName) && $zoneName === $configuration['zoneName']) {
                         $adapter = $this->adapter($configuration['apiKey']);
                         $zones = new Zones($adapter);
                         $result[] = [


### PR DESCRIPTION
If there is no zoneName configured, no caches should be flushed.